### PR TITLE
Added typer.Typer.async_command function.

### DIFF
--- a/typer/main.py
+++ b/typer/main.py
@@ -5,6 +5,7 @@ from functools import update_wrapper, wraps
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Type, Union
 from uuid import UUID
+from asyncio import run
 
 import click
 


### PR DESCRIPTION
From my comment in:

https://github.com/tiangolo/typer/issues/88

Allows command to be used with async.

Let me know if using *args, **kwargs is ok or if it needs to be typed. *args, **kwargs will be more maintainable. Further we could just make @app.command DETECT if it's attached to an async function, but that might be more challenging.